### PR TITLE
Fix script path references in pages

### DIFF
--- a/pages/Products.html
+++ b/pages/Products.html
@@ -235,6 +235,6 @@
   </footer>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
-  <script src="../scripts.js"></script>
+  <script src="../js/scripts.js"></script>
 </body>
 </html>

--- a/pages/tally-customization.html
+++ b/pages/tally-customization.html
@@ -163,6 +163,6 @@
   </footer>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
-  <script src="../scripts.js"></script>
+  <script src="../js/scripts.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- correct script path in `pages/Products.html`
- correct script path in `pages/tally-customization.html`

## Testing
- `grep -R "src=\"../scripts.js\"" -n pages`
- `grep -R "../js/scripts.js" -n pages | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_684698b4cd1c832da680ddeb70e56f41