### PR TITLE
Add social meta tags to home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,16 @@
 <!-- Declare the sitemap location for crawlers -->
 <link rel="sitemap" type="application/xml" title="Sitemap" href="https://rivedainfosoft.com/sitemap.xml" />
 
+  <link rel="canonical" href="https://rivedainfosoft.com/">
+  <meta property="og:title" content="Riveda Infosoft">
+  <meta property="og:description" content="Riveda Infosoft - Your Tally Solutions Partner">
+  <meta property="og:image" content="https://rivedainfosoft.com/images/logo-transparent-png.webp">
+  <meta property="og:url" content="https://rivedainfosoft.com/">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Riveda Infosoft">
+  <meta name="twitter:description" content="Riveda Infosoft - Your Tally Solutions Partner">
+  <meta name="twitter:image" content="https://rivedainfosoft.com/images/logo-transparent-png.webp">
   <style>
     .marquee-container {
       width: 100%;


### PR DESCRIPTION
## Summary
- improve sharing support with Open Graph and Twitter meta tags
- add canonical link for the homepage

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68469a45bb1c832da23fa423053de61f