### PR TITLE
Embed reusable analytics snippet

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
   <meta name="twitter:title" content="Riveda Infosoft">
   <meta name="twitter:description" content="Riveda Infosoft - Your Tally Solutions Partner">
   <meta name="twitter:image" content="https://rivedainfosoft.com/images/logo-transparent-png.webp">
+  <script src="js/ga.js" defer></script>
   <style>
     .marquee-container {
       width: 100%;

--- a/js/ga.js
+++ b/js/ga.js
@@ -1,0 +1,11 @@
+(function(){
+  var script=document.createElement('script');
+  script.async=true;
+  script.src='https://www.googletagmanager.com/gtag/js?id=G-0000000000';
+  document.head.appendChild(script);
+
+  window.dataLayer=window.dataLayer||[];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-0000000000');
+})();

--- a/pages/Products.html
+++ b/pages/Products.html
@@ -8,6 +8,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../css/styles.css">
+    <script src="../js/ga.js" defer></script>
   <style>
     .marquee-container {
       width: 100%;

--- a/pages/about-us.html
+++ b/pages/about-us.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../css/styles.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
+    <script src="../js/ga.js" defer></script>
   <style>
     .marquee-container {
       width: 100%;

--- a/pages/accounting-taxation.html
+++ b/pages/accounting-taxation.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../css/styles.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
+    <script src="../js/ga.js" defer></script>
   <style>
     .marquee-container {
       width: 100%;

--- a/pages/advanced-document-manager.html
+++ b/pages/advanced-document-manager.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../css/styles.css">
+      <script src="../js/ga.js" defer></script>
     <style>
       .marquee-container {
         width: 100%;

--- a/pages/chitfund-soft.html
+++ b/pages/chitfund-soft.html
@@ -27,6 +27,7 @@
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     
+      <script src="../js/ga.js" defer></script>
     <style>
       html {
         scroll-behavior: smooth;

--- a/pages/gst-easymatch.html
+++ b/pages/gst-easymatch.html
@@ -27,6 +27,7 @@
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     
+      <script src="../js/ga.js" defer></script>
     <style>
         html {
             scroll-behavior: smooth;

--- a/pages/pdf-to-excel.html
+++ b/pages/pdf-to-excel.html
@@ -27,6 +27,7 @@
   <link rel="stylesheet" href="../css/styles.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
   
+    <script src="../js/ga.js" defer></script>
   <style>
     html {
       scroll-behavior: smooth;

--- a/pages/privacy-policy.html
+++ b/pages/privacy-policy.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../css/styles.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
+    <script src="../js/ga.js" defer></script>
   <style>
     .marquee-container {
       width: 100%;

--- a/pages/school-college-soft.html
+++ b/pages/school-college-soft.html
@@ -27,6 +27,7 @@
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     
+      <script src="../js/ga.js" defer></script>
     <style>
       html {
         scroll-behavior: smooth;

--- a/pages/tally-auto-backup.html
+++ b/pages/tally-auto-backup.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../css/styles.css">
+      <script src="../js/ga.js" defer></script>
     <style>
       .marquee-container {
         width: 100%;

--- a/pages/tally-customizations.html
+++ b/pages/tally-customizations.html
@@ -9,6 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
+      <script src="../js/ga.js" defer></script>
     <style>
         .marquee-container {
             width: 100%;

--- a/pages/tally-hospital-module.html
+++ b/pages/tally-hospital-module.html
@@ -27,6 +27,7 @@
   <link rel="stylesheet" href="../css/styles.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
   
+    <script src="../js/ga.js" defer></script>
   <style>
     html {
       scroll-behavior: smooth;

--- a/pages/tally-integration.html
+++ b/pages/tally-integration.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../css/styles.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
+    <script src="../js/ga.js" defer></script>
   <style>
     .marquee-container {
       width: 100%;

--- a/pages/tally-license.html
+++ b/pages/tally-license.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../css/styles.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
+    <script src="../js/ga.js" defer></script>
   <style>
     .marquee-container {
       width: 100%;

--- a/pages/tally-society-connect.html
+++ b/pages/tally-society-connect.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../css/styles.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
+    <script src="../js/ga.js" defer></script>
   <style>
     .marquee-container {
       width: 100%;

--- a/pages/tallybridge.html
+++ b/pages/tallybridge.html
@@ -27,6 +27,7 @@
   <link rel="stylesheet" href="../css/styles.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
   
+    <script src="../js/ga.js" defer></script>
   <style>
     html {
       scroll-behavior: smooth;

--- a/pages/terms-of-use.html
+++ b/pages/terms-of-use.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../css/styles.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
+    <script src="../js/ga.js" defer></script>
   <style>
     .marquee-container {
       width: 100%;

--- a/thank-you.html
+++ b/thank-you.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/styles.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
+    <script src="js/ga.js" defer></script>
   <style>
     .thank-you-section {
       min-height: 80vh;


### PR DESCRIPTION
## Summary
- create a reusable GA loader script
- include new GA script on the homepage and all subpages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846d0537db0832d851b5a6264dddbe6